### PR TITLE
Make fixed star name parameter ref

### DIFF
--- a/Programs/SweTest/Program.cs
+++ b/Programs/SweTest/Program.cs
@@ -1724,7 +1724,7 @@ namespace SweTest
                                 iflag = iflag_f;
                             if (ipl == SwissEph.SE_FIXSTAR)
                             {
-                                iflgret = sweph.swe_fixstar(star, te, iflag, x, ref serr);
+                                iflgret = sweph.swe_fixstar(ref star, te, iflag, x, ref serr);
                                 /* magnitude, etc. */
                                 if (iflgret != SwissEph.ERR && fmt.IndexOf('=') >= 0)
                                 {
@@ -1827,7 +1827,7 @@ namespace SweTest
                             {
                                 iflag2 = iflag | SwissEph.SEFLG_EQUATORIAL;
                                 if (ipl == SwissEph.SE_FIXSTAR)
-                                    iflgret = sweph.swe_fixstar(star, te, iflag2, xequ, ref serr);
+                                    iflgret = sweph.swe_fixstar(ref star, te, iflag2, xequ, ref serr);
                                 else
                                     iflgret = sweph.swe_calc(te, ipl, iflag2, xequ, ref serr);
                                 if (diff_mode != 0)
@@ -1859,7 +1859,7 @@ namespace SweTest
                                 /* first, get topocentric equatorial positions */
                                 iflgt = whicheph | SwissEph.SEFLG_EQUATORIAL | SwissEph.SEFLG_TOPOCTR;
                                 if (ipl == SwissEph.SE_FIXSTAR)
-                                    iflgret = sweph.swe_fixstar(star, te, iflgt, xt, ref serr);
+                                    iflgret = sweph.swe_fixstar(ref star, te, iflgt, xt, ref serr);
                                 else
                                     iflgret = sweph.swe_calc(te, ipl, iflgt, xt, ref serr);
                                 /* to azimuth/height */
@@ -1897,7 +1897,7 @@ namespace SweTest
                             {
                                 iflag2 = iflag | SwissEph.SEFLG_XYZ;
                                 if (ipl == SwissEph.SE_FIXSTAR)
-                                    iflgret = sweph.swe_fixstar(star, te, iflag2, xcart, ref serr);
+                                    iflgret = sweph.swe_fixstar(ref star, te, iflag2, xcart, ref serr);
                                 else
                                     iflgret = sweph.swe_calc(te, ipl, iflag2, xcart, ref serr);
                                 if (diff_mode != 0)
@@ -1919,7 +1919,7 @@ namespace SweTest
                             {
                                 iflag2 = iflag | SwissEph.SEFLG_XYZ | SwissEph.SEFLG_EQUATORIAL;
                                 if (ipl == SwissEph.SE_FIXSTAR)
-                                    iflgret = sweph.swe_fixstar(star, te, iflag2, xcartq, ref serr);
+                                    iflgret = sweph.swe_fixstar(ref star, te, iflag2, xcartq, ref serr);
                                 else
                                     iflgret = sweph.swe_calc(te, ipl, iflag2, xcartq, ref serr);
                                 if (diff_mode != 0)

--- a/Programs/SweWin/FormData.cs
+++ b/Programs/SweWin/FormData.cs
@@ -664,7 +664,7 @@ namespace SweWin
                         continue;
                 /* ecliptic position */
                 if (ipl == SwissEph.SE_FIXSTAR) {
-                    iflgret = sweph.swe_fixstar(star, tjd_et, iflag, x, ref serr);
+                    iflgret = sweph.swe_fixstar(ref star, tjd_et, iflag, x, ref serr);
                     se_pname = star;
                 } else {
                     iflgret = sweph.swe_calc(tjd_et, ipl, iflag, x, ref serr);
@@ -694,7 +694,7 @@ namespace SweWin
                 if (fmt.IndexOfAny("aADdQ".ToCharArray()) >= 0) {
                     iflag2 = iflag | SwissEph.SEFLG_EQUATORIAL;
                     if (ipl == SwissEph.SE_FIXSTAR)
-                        iflgret = sweph.swe_fixstar(star, tjd_et, iflag2, xequ, ref serr);
+                        iflgret = sweph.swe_fixstar(ref star, tjd_et, iflag2, xequ, ref serr);
                     else
                         iflgret = sweph.swe_calc(tjd_et, ipl, iflag2, xequ, ref serr);
                 }
@@ -702,7 +702,7 @@ namespace SweWin
                 if (fmt.IndexOfAny("XU".ToCharArray()) >= 0) {
                     iflag2 = iflag | SwissEph.SEFLG_XYZ;
                     if (ipl == SwissEph.SE_FIXSTAR)
-                        iflgret = sweph.swe_fixstar(star, tjd_et, iflag2, xcart, ref serr);
+                        iflgret = sweph.swe_fixstar(ref star, tjd_et, iflag2, xcart, ref serr);
                     else
                         iflgret = sweph.swe_calc(tjd_et, ipl, iflag2, xcart, ref serr);
                 }
@@ -710,7 +710,7 @@ namespace SweWin
                 if (fmt.IndexOfAny("xu".ToCharArray()) >= 0) {
                     iflag2 = iflag | SwissEph.SEFLG_XYZ | SwissEph.SEFLG_EQUATORIAL;
                     if (ipl == SwissEph.SE_FIXSTAR)
-                        iflgret = sweph.swe_fixstar(star, tjd_et, iflag2, xcartq, ref serr);
+                        iflgret = sweph.swe_fixstar(ref star, tjd_et, iflag2, xcartq, ref serr);
                     else
                         iflgret = sweph.swe_calc(tjd_et, ipl, iflag2, xcartq, ref serr);
                 }

--- a/SwissEphNet/CPort/SweCL.cs
+++ b/SwissEphNet/CPort/SweCL.cs
@@ -879,7 +879,7 @@ namespace SwissEphNet.CPort
             if (String.IsNullOrEmpty(starname)) {
                 retc = SE.swe_calc(tjd_et, ipl, iflag, x, ref serr);
             } else {
-                if ((retc = SE.swe_fixstar(starname, tjd_et, iflag, x, ref serr)) == SwissEph.OK) {
+                if ((retc = SE.swe_fixstar(ref starname, tjd_et, iflag, x, ref serr)) == SwissEph.OK) {
                     /* fixstars have the standard distance 1. 
                      * in the occultation routines, this might lead to errors 
                      * if interpreted as AU distance. To avoid this, we make it very high.
@@ -4219,7 +4219,7 @@ namespace SwissEphNet.CPort
              * western half of the sky for a short time. 
              */
             if (do_fixstar) {
-                if (SE.swe_fixstar(starname, tjd_et, iflag, xc, ref serr) == SwissEph.ERR)
+                if (SE.swe_fixstar(ref starname, tjd_et, iflag, xc, ref serr) == SwissEph.ERR)
                     return SwissEph.ERR;
             }
             for (ii = 0, t = tjd_ut - twohrs; ii <= jmax; ii++, t += twohrs) {
@@ -4463,7 +4463,7 @@ namespace SwissEphNet.CPort
                 armc0 += 24;
             armc0 *= 15;
             if (do_fixstar) {
-                if (SE.swe_fixstar(starname, tjd_et, iflag, x0, ref serr) == SwissEph.ERR)
+                if (SE.swe_fixstar(ref starname, tjd_et, iflag, x0, ref serr) == SwissEph.ERR)
                     return SwissEph.ERR;
             } else {
                 if (SE.swe_calc(tjd_et, ipl, iflag, x0, ref serr) == SwissEph.ERR)
@@ -6150,7 +6150,7 @@ static const double Gmsm_factor_AA[] = {
                 nutlo[1] *= SwissEph.RADTODEG;
                 armc = SE.swe_degnorm(SE.swe_sidtime0(t_ut, eps + nutlo[1], nutlo[0]) * 15 + geopos[0]);
                 if (do_fixstar) {
-                    if (SE.swe_fixstar(starname, t_et, iflag, x0, ref serr) == SwissEph.ERR)
+                    if (SE.swe_fixstar(ref starname, t_et, iflag, x0, ref serr) == SwissEph.ERR)
                         return SwissEph.ERR;
                 } else {
                     if (SE.swe_calc(t_et, ipl, iflag, x0, ref serr) == SwissEph.ERR)

--- a/SwissEphNet/CPort/SweHel.cs
+++ b/SwissEphNet/CPort/SweHel.cs
@@ -382,7 +382,7 @@ namespace SwissEphNet.CPort
         Int32 call_swe_fixstar(string star, double tjd, Int32 iflag, double[] xx, ref string serr) {
             Int32 retval;
             string star2 = star;
-            retval = SE.swe_fixstar(star2, tjd, iflag, xx, ref serr);
+            retval = SE.swe_fixstar(ref star2, tjd, iflag, xx, ref serr);
             return retval;
         }
 
@@ -2411,7 +2411,7 @@ namespace SwissEphNet.CPort
             string star2;
             star2 = star;
             if (ipl == -1) {
-                if ((retval = SE.swe_fixstar(star2, tjd, epheflag | SwissEph.SEFLG_EQUATORIAL, x, ref serr)) == SwissEph.ERR)
+                if ((retval = SE.swe_fixstar(ref star2, tjd, epheflag | SwissEph.SEFLG_EQUATORIAL, x, ref serr)) == SwissEph.ERR)
                     return SwissEph.ERR;
             } else {
                 if ((retval = SE.swe_calc(tjd, ipl, epheflag | SwissEph.SEFLG_EQUATORIAL, x, ref serr)) == SwissEph.ERR)

--- a/SwissEphNet/CPort/Sweph.cs
+++ b/SwissEphNet/CPort/Sweph.cs
@@ -2970,7 +2970,7 @@ namespace SwissEphNet.CPort
                 swe_set_sid_mode(SwissEph.SE_SIDM_FAGAN_BRADLEY, 0, 0);
             if (sip.sid_mode == SwissEph.SE_SIDM_TRUE_CITRA) {
                 star = "Spica"; /* Citra */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true, x, ref serr)) == ERR)
                 {
                     return ERR;
                 }
@@ -2980,7 +2980,7 @@ namespace SwissEphNet.CPort
             }
             if (sip.sid_mode == SwissEph.SE_SIDM_TRUE_REVATI) {
                 star = ",zePsc"; /* Revati */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 359.8333333333);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -2988,7 +2988,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_TRUE_PUSHYA)
             {
                 star = ",deCnc"; /* Pushya = Asellus Australis */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 106);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -2996,7 +2996,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_TRUE_MULA)
             {
                 star = ",laSco"; /* Mula = lambda Scorpionis */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 240);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -3004,7 +3004,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_GALCENT_0SAG)
             {
                 star = ",SgrA*"; /* Galactic Centre */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 240.0);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -3013,7 +3013,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_GALCENT_RGILBRAND)
             {
                 star = ",SgrA*"; /* Galactic Centre */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 210.0 - 90.0 * 0.3819660113);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -3024,7 +3024,7 @@ namespace SwissEphNet.CPort
                 star = ",SgrA*"; /* Galactic Centre */
                 /* right ascension in polar projection onto the ecliptic, 
                  * and that point is put in the middle of Mula */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_true | SwissEph.SEFLG_EQUATORIAL, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_true | SwissEph.SEFLG_EQUATORIAL, x, ref serr)) == ERR)
                     return ERR;
                 eps = SE.SwephLib.swi_epsiln(tjd_et, iflag) * SwissEph.RADTODEG;
                 daya = SE.SweHouse.swi_armc_to_mc(x[0], eps);
@@ -3035,7 +3035,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_GALEQU_IAU1958)
             {
                 star = ",GP1958"; /* Galactic Pole IAU 1958 */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_galequ, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_galequ, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 150);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -3043,7 +3043,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_GALEQU_TRUE)
             {
                 star = ",GPol"; /* Galactic Pole modern, true */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_galequ, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_galequ, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 150);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -3051,7 +3051,7 @@ namespace SwissEphNet.CPort
             if (sip.sid_mode == SwissEph.SE_SIDM_GALEQU_MULA)
             {
                 star = ",GPol"; /* Galactic Pole modern, true */
-                if ((retflag = swe_fixstar(star, tjd_et, iflag_galequ, x, ref serr)) == ERR)
+                if ((retflag = swe_fixstar(ref star, tjd_et, iflag_galequ, x, ref serr)) == ERR)
                     return ERR;
                 daya = SE.swe_degnorm(x[0] - 150 - 6.6666666667);
                 return (retflag & SwissEph.SEFLG_EPHMASK);
@@ -6051,7 +6051,7 @@ namespace SwissEphNet.CPort
         string slast_stardata = String.Empty;
         string slast_starname = String.Empty;
         string sdummy = null;
-        public Int32 swe_fixstar(string star, double tjd, Int32 iflag,
+        public Int32 swe_fixstar(ref string star, double tjd, Int32 iflag,
           double[] xx, ref string serr) {
             int i;
             int star_nr = 0;
@@ -6261,6 +6261,7 @@ namespace SwissEphNet.CPort
         found:
             slast_stardata = s;
             slast_starname = sstar;
+            // star = sstar;
             //i = swi_cutstr(s, ",", cpos, 20);
             //swi_right_trim(cpos[0]);
             //swi_right_trim(cpos[1]);
@@ -6563,7 +6564,7 @@ namespace SwissEphNet.CPort
             return retc;
         }
 
-        public Int32 swe_fixstar_ut(string star, double tjd_ut, Int32 iflag,
+        public Int32 swe_fixstar_ut(ref string star, double tjd_ut, Int32 iflag,
           double[] xx, ref string serr) {
               double deltat;
               Int32 retflag;
@@ -6578,11 +6579,11 @@ namespace SwissEphNet.CPort
               }
               deltat = SE.swe_deltat_ex(tjd_ut, iflag, ref serr);
               /* if ephe required is not ephe returned, adjust delta t: */
-              retflag = swe_fixstar(star, tjd_ut + deltat, iflag, xx, ref serr);
+              retflag = swe_fixstar(ref star, tjd_ut + deltat, iflag, xx, ref serr);
               if ((retflag & SwissEph.SEFLG_EPHMASK) != epheflag)
               {
                   deltat = SE.swe_deltat_ex(tjd_ut, retflag, ref sdummy);
-                  retflag = swe_fixstar(star, tjd_ut + deltat, iflag, xx, ref sdummy);
+                  retflag = swe_fixstar(ref star, tjd_ut + deltat, iflag, xx, ref sdummy);
               }
               return retflag;
           }

--- a/SwissEphNet/SwissEph.swephexp.h.cs
+++ b/SwissEphNet/SwissEph.swephexp.h.cs
@@ -671,13 +671,13 @@ namespace SwissEphNet
         /// <summary>
         /// fixed stars
         /// </summary>
-        public Int32 swe_fixstar(string star, double tjd, Int32 iflag, double[] xx, ref string serr)
+        public Int32 swe_fixstar(ref string star, double tjd, Int32 iflag, double[] xx, ref string serr)
         {
-            return Sweph.swe_fixstar(star, tjd, iflag, xx, ref serr);
+            return Sweph.swe_fixstar(ref star, tjd, iflag, xx, ref serr);
         }
-        public Int32 swe_fixstar_ut(string star, double tjd_ut, Int32 iflag, double[] xx, ref string serr)
+        public Int32 swe_fixstar_ut(ref string star, double tjd_ut, Int32 iflag, double[] xx, ref string serr)
         {
-            return Sweph.swe_fixstar_ut(star, tjd_ut, iflag, xx, ref serr);
+            return Sweph.swe_fixstar_ut(ref star, tjd_ut, iflag, xx, ref serr);
         }
         public Int32 swe_fixstar_mag(ref string star, ref double mag, ref string serr)
         {


### PR DESCRIPTION
As per the docs:

```
The parameter star must provide for at least 41 characters for the returned star name. If a star is found, its **name is returned in this field** in the following format:
traditional_name, nomenclature_name e.g. "Aldebaran,alTau".
```

By marking the parameter as ref, the value set during the calculations gets propagated to the caller.